### PR TITLE
Added JSON capacity

### DIFF
--- a/BudgetAnalyzer.Shared/BudgetAnalyzer.Shared.csproj
+++ b/BudgetAnalyzer.Shared/BudgetAnalyzer.Shared.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Maui" Version="9.0.3" />
     <PackageReference Include="MudBlazor" Version="7.6.0" />
   </ItemGroup>
 

--- a/BudgetAnalyzer.Shared/Components/Controls/AppSettingsEditor.razor
+++ b/BudgetAnalyzer.Shared/Components/Controls/AppSettingsEditor.razor
@@ -14,9 +14,20 @@
     </MudSelect>
 </MudStack>
 
+<MudStack Spacing="0" Class="mt-4">
+    <MudButton Variant="Variant.Text" OnClick="() => ShowState = !ShowState">Show Current App Data</MudButton>
+    <MudDivider />
+    <MudCollapse Expanded="ShowState">
+        <pre>
+            @State.ToJson()
+        </pre>
+    </MudCollapse>
+</MudStack>
+
 
 @code {
     private AppSettings Settings => State.Settings;
+    private bool ShowState { get; set; } = false;
 
     private void SetSelectedBudget(Guid selectedBudget) => AddAction(new SetSelectedBudgetAction(selectedBudget));
 }

--- a/BudgetAnalyzer.Shared/Components/Layout/AppBar.razor
+++ b/BudgetAnalyzer.Shared/Components/Layout/AppBar.razor
@@ -1,4 +1,4 @@
-@using CommunityToolkit.Maui.Storage;
+@using BudgetAnalyzer.Shared.Data;
 @namespace BudgetAnalyzer.Shared.Layout
 @inherits SubscribedComponent
 
@@ -34,24 +34,13 @@
 @code{
     public async Task FileUpload()
     {
-        FilePickerFileType allowedFileTypes = new(
-                new Dictionary<DevicePlatform, IEnumerable<string>>
-                {
-                    { DevicePlatform.WinUI, new[] { ".json" } }
-                });
+        string? fileText = await AppDataTransporter.UploadJsonFile();
 
-        PickOptions options = new() { FileTypes = allowedFileTypes };
-        FileResult? fileResult = await FilePicker.PickAsync(options);
-        if (fileResult is null) return;
-
-        Stream fileStream = await fileResult.OpenReadAsync();
-        StreamReader reader = new(fileStream);
-
-        string fileText = await reader.ReadToEndAsync();
+        if (fileText is null) return;
         AddAction(new SetAppFromJsonAction(fileText));
     }
 
-    public async Task FileDownload() => await FileSaver.SaveAsync("AppData.json", new MemoryStream(State.ToJsonByteArray()));
+    public async Task FileDownload() => await AppDataTransporter.DownloadJsonFile(State);
+    public async Task CopyAppData() => await AppDataTransporter.CopyJson(State);
 
-    public async Task CopyAppData() => await Clipboard.SetTextAsync(State.ToJson());
 }

--- a/BudgetAnalyzer.Shared/Components/Layout/AppBar.razor
+++ b/BudgetAnalyzer.Shared/Components/Layout/AppBar.razor
@@ -2,7 +2,15 @@
 @inherits SubscribedComponent
 
 <MudAppBar>
-    <MudIcon Icon="@Icons.Material.Filled.Menu" />
+    <MudMenu Icon="@Icons.Material.Filled.Menu">
+        <MudMenuItem>
+            <MudFileUpload T="IBrowserFile" Accept=".json" FilesChanged="FileUpload">
+                <ActivatorContent>
+                    <MudButton StartIcon="@Icons.Material.Filled.FileUpload">Upload App Data</MudButton>
+                </ActivatorContent>
+            </MudFileUpload>
+        </MudMenuItem>
+    </MudMenu>
     <MudSpacer />
 
     <MudButtonGroup Color="Color.Tertiary" Variant="Variant.Text">
@@ -18,3 +26,15 @@
     <MudIconButton Icon="@Icons.Material.Filled.Code" Href="https://github.com/Jorden-Quast/BudgetAnalyzer" />
 </MudAppBar>
 
+@code{
+    public async Task FileUpload(IBrowserFile newFile)
+    {
+        Stream fileStream = newFile.OpenReadStream();
+        StreamReader reader = new(fileStream);
+        string fileText = await reader.ReadToEndAsync();
+
+        AddAction(new SetAppFromJsonAction(fileText));
+
+
+    }
+}

--- a/BudgetAnalyzer.Shared/Components/Layout/AppBar.razor
+++ b/BudgetAnalyzer.Shared/Components/Layout/AppBar.razor
@@ -1,14 +1,15 @@
+@using CommunityToolkit.Maui.Storage;
 @namespace BudgetAnalyzer.Shared.Layout
 @inherits SubscribedComponent
 
 <MudAppBar>
     <MudMenu Icon="@Icons.Material.Filled.Menu">
-        <MudMenuItem>
-            <MudFileUpload T="IBrowserFile" Accept=".json" FilesChanged="FileUpload">
-                <ActivatorContent>
-                    <MudButton StartIcon="@Icons.Material.Filled.FileUpload">Upload App Data</MudButton>
-                </ActivatorContent>
-            </MudFileUpload>
+        <MudMenuItem Icon="@Icons.Material.Filled.FileUpload" OnClick="FileUpload">
+            Upload App Data
+        </MudMenuItem>
+
+        <MudMenuItem Icon="@Icons.Material.Filled.FileDownload" OnClick="FileDownload">
+            Download App Data
         </MudMenuItem>
     </MudMenu>
     <MudSpacer />
@@ -27,14 +28,24 @@
 </MudAppBar>
 
 @code{
-    public async Task FileUpload(IBrowserFile newFile)
+    public async Task FileUpload()
     {
-        Stream fileStream = newFile.OpenReadStream();
+        FilePickerFileType allowedFileTypes = new(
+                new Dictionary<DevicePlatform, IEnumerable<string>>
+                {
+                    { DevicePlatform.WinUI, new[] { ".json" } }
+                });
+
+        PickOptions options = new() { FileTypes = allowedFileTypes };
+        FileResult? fileResult = await FilePicker.PickAsync(options);
+        if (fileResult is null) return;
+
+        Stream fileStream = await fileResult.OpenReadAsync();
         StreamReader reader = new(fileStream);
+
         string fileText = await reader.ReadToEndAsync();
-
         AddAction(new SetAppFromJsonAction(fileText));
-
-
     }
+
+    public async Task FileDownload() => await FileSaver.SaveAsync("AppData.json", new MemoryStream(State.ToJsonByteArray(true)));
 }

--- a/BudgetAnalyzer.Shared/Components/Layout/AppBar.razor
+++ b/BudgetAnalyzer.Shared/Components/Layout/AppBar.razor
@@ -3,13 +3,17 @@
 @inherits SubscribedComponent
 
 <MudAppBar>
-    <MudMenu Icon="@Icons.Material.Filled.Menu">
+    <MudMenu Icon="@Icons.Material.Filled.Menu" AnchorOrigin="Origin.CenterCenter">
         <MudMenuItem Icon="@Icons.Material.Filled.FileUpload" OnClick="FileUpload">
             Upload App Data
         </MudMenuItem>
 
         <MudMenuItem Icon="@Icons.Material.Filled.FileDownload" OnClick="FileDownload">
             Download App Data
+        </MudMenuItem>
+
+        <MudMenuItem Icon="@Icons.Material.Filled.ContentCopy" OnClick="CopyAppData">
+            Copy App Data to Clipboard
         </MudMenuItem>
     </MudMenu>
     <MudSpacer />
@@ -47,5 +51,7 @@
         AddAction(new SetAppFromJsonAction(fileText));
     }
 
-    public async Task FileDownload() => await FileSaver.SaveAsync("AppData.json", new MemoryStream(State.ToJsonByteArray(true)));
+    public async Task FileDownload() => await FileSaver.SaveAsync("AppData.json", new MemoryStream(State.ToJsonByteArray()));
+
+    public async Task CopyAppData() => await Clipboard.SetTextAsync(State.ToJson());
 }

--- a/BudgetAnalyzer.Shared/Data/AppDataTransporter.cs
+++ b/BudgetAnalyzer.Shared/Data/AppDataTransporter.cs
@@ -1,0 +1,30 @@
+﻿using BudgetAnalyzer.Shared.State;
+using CommunityToolkit.Maui.Storage;
+
+namespace BudgetAnalyzer.Shared.Data;
+
+public static class AppDataTransporter
+{
+    public static async Task<string?> UploadJsonFile()
+    {
+        FilePickerFileType allowedFileTypes = new(
+                new Dictionary<DevicePlatform, IEnumerable<string>>
+                {
+                    { DevicePlatform.WinUI, new[] { ".json" } }
+                });
+
+        PickOptions options = new() { FileTypes = allowedFileTypes };
+        FileResult? fileResult = await FilePicker.PickAsync(options);
+        if (fileResult is null) return null;
+
+        Stream fileStream = await fileResult.OpenReadAsync();
+        StreamReader reader = new(fileStream);
+
+        string fileText = await reader.ReadToEndAsync();
+
+        return fileText;
+    }
+
+    public static async Task DownloadJsonFile(AnalyzerState state) => await FileSaver.SaveAsync("AppData.json", new MemoryStream(state.ToJsonByteArray()));
+    public static async Task CopyJson(AnalyzerState state) => await Clipboard.SetTextAsync(state.ToJson());
+}

--- a/BudgetAnalyzer.Shared/Data/Budget.cs
+++ b/BudgetAnalyzer.Shared/Data/Budget.cs
@@ -5,14 +5,14 @@ namespace BudgetAnalyzer.Shared.Data;
 
 public record BudgetCategory(string Name, decimal Percentage, decimal? Cutoff) 
 {
-    public readonly Guid Id = Guid.NewGuid();
+    public Guid Id { get; init; } = Guid.NewGuid();
 
     public static BudgetCategory Default => new("Default Cagetory", 0, null); 
 }
 
 public sealed record Budget(string Name, ImmutableList<BudgetCategory> Categories)
 {
-    public readonly Guid Id = Guid.NewGuid();
+    public Guid Id { get; init; } = Guid.NewGuid();
     public static Budget Default => new("Default Budget", []);
 
     public bool IsValid(out string? errorMessage)

--- a/BudgetAnalyzer.Shared/Data/State/Actions/SetAppFromJsonAction.cs
+++ b/BudgetAnalyzer.Shared/Data/State/Actions/SetAppFromJsonAction.cs
@@ -1,0 +1,7 @@
+﻿namespace BudgetAnalyzer.Shared.State;
+
+/// <summary> Tries to parse the json string, returning a default state if failed </summary>
+public record class SetAppFromJsonAction(string JsonString) : IAction
+{
+    public AnalyzerState UpdateState(AnalyzerState state) => AnalyzerState.FromJsonOrDefault(JsonString) ?? new AnalyzerState();
+}

--- a/BudgetAnalyzer.Shared/Data/State/Actions/SetAppFromJsonAction.cs
+++ b/BudgetAnalyzer.Shared/Data/State/Actions/SetAppFromJsonAction.cs
@@ -1,7 +1,7 @@
 ﻿namespace BudgetAnalyzer.Shared.State;
 
-/// <summary> Tries to parse the json string, returning a default state if failed </summary>
+/// <summary> Tries to parse the json string, doing nothing if parsing failed </summary>
 public record class SetAppFromJsonAction(string JsonString) : IAction
 {
-    public AnalyzerState UpdateState(AnalyzerState state) => AnalyzerState.FromJsonOrDefault(JsonString) ?? new AnalyzerState();
+    public AnalyzerState UpdateState(AnalyzerState state) => AnalyzerState.FromJsonOrDefault(JsonString) ?? state;
 }

--- a/BudgetAnalyzer.Shared/Data/State/AnalyzerState.cs
+++ b/BudgetAnalyzer.Shared/Data/State/AnalyzerState.cs
@@ -2,6 +2,7 @@
 using System.Collections.Immutable;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace BudgetAnalyzer.Shared.State;
 
@@ -9,6 +10,8 @@ public record AnalyzerState
 {
     public AppSettings Settings { get; init; }
     public ImmutableList<Budget> AvailableBudgets { get; init; }
+
+    [JsonIgnore]
     public Budget? SelectedBudget => AvailableBudgets.FirstOrDefault(b => b.Id == Settings.CurrentBudgetId);
 
     public AnalyzerState()
@@ -17,8 +20,8 @@ public record AnalyzerState
         Settings = new AppSettings(AvailableBudgets.First().Id);
     }
 
-    public string ToJson(bool prettyOutput = false) => JsonSerializer.Serialize(this, new JsonSerializerOptions() { WriteIndented = prettyOutput});
-    public byte[] ToJsonByteArray(bool prettyOutput = false) => Encoding.Default.GetBytes(ToJson(prettyOutput));
+    public string ToJson(bool prettyOutput = true) => JsonSerializer.Serialize(this, new JsonSerializerOptions() { WriteIndented = prettyOutput});
+    public byte[] ToJsonByteArray(bool prettyOutput = true) => Encoding.Default.GetBytes(ToJson(prettyOutput));
 
     public static AnalyzerState FromJson(string jsonString) => FromJsonOrDefault(jsonString) ?? throw new ArgumentNullException($"{nameof(jsonString)} could not be parsed");
     public static AnalyzerState? FromJsonOrDefault(string jsonString) => JsonSerializer.Deserialize<AnalyzerState>(jsonString);

--- a/BudgetAnalyzer.Shared/Data/State/AnalyzerState.cs
+++ b/BudgetAnalyzer.Shared/Data/State/AnalyzerState.cs
@@ -1,5 +1,6 @@
 ﻿using BudgetAnalyzer.Shared.Data;
 using System.Collections.Immutable;
+using System.Text;
 using System.Text.Json;
 
 namespace BudgetAnalyzer.Shared.State;
@@ -16,7 +17,9 @@ public record AnalyzerState
         Settings = new AppSettings(AvailableBudgets.First().Id);
     }
 
-    public string ToJson(bool writeIndented = false) => JsonSerializer.Serialize(this, new JsonSerializerOptions() { WriteIndented = writeIndented});
+    public string ToJson(bool prettyOutput = false) => JsonSerializer.Serialize(this, new JsonSerializerOptions() { WriteIndented = prettyOutput});
+    public byte[] ToJsonByteArray(bool prettyOutput = false) => Encoding.Default.GetBytes(ToJson(prettyOutput));
+
     public static AnalyzerState FromJson(string jsonString) => FromJsonOrDefault(jsonString) ?? throw new ArgumentNullException($"{nameof(jsonString)} could not be parsed");
     public static AnalyzerState? FromJsonOrDefault(string jsonString) => JsonSerializer.Deserialize<AnalyzerState>(jsonString);
 }

--- a/BudgetAnalyzer.Shared/Data/State/AnalyzerState.cs
+++ b/BudgetAnalyzer.Shared/Data/State/AnalyzerState.cs
@@ -1,5 +1,6 @@
 ﻿using BudgetAnalyzer.Shared.Data;
 using System.Collections.Immutable;
+using System.Text.Json;
 
 namespace BudgetAnalyzer.Shared.State;
 
@@ -14,4 +15,8 @@ public record AnalyzerState
         AvailableBudgets = ImmutableList.Create([Budget.Default]);
         Settings = new AppSettings(AvailableBudgets.First().Id);
     }
+
+    public string ToJson(bool writeIndented = false) => JsonSerializer.Serialize(this, new JsonSerializerOptions() { WriteIndented = writeIndented});
+    public static AnalyzerState FromJson(string jsonString) => FromJsonOrDefault(jsonString) ?? throw new ArgumentNullException($"{nameof(jsonString)} could not be parsed");
+    public static AnalyzerState? FromJsonOrDefault(string jsonString) => JsonSerializer.Deserialize<AnalyzerState>(jsonString);
 }

--- a/BudgetAnalyzer.Shared/Data/State/StateManager.cs
+++ b/BudgetAnalyzer.Shared/Data/State/StateManager.cs
@@ -20,7 +20,7 @@ public class StateManager
         if (!File.Exists(DocPath))
         {
             AnalyzerState defaultState = new();
-            File.WriteAllText(DocPath, defaultState.ToJson(true));
+            File.WriteAllText(DocPath, defaultState.ToJson(false));
             return defaultState;
         }
 
@@ -30,7 +30,7 @@ public class StateManager
 
     private void SaveState()
     {
-        string serializedState = _State.ToJson(true);
+        string serializedState = _State.ToJson(false);
         File.WriteAllText(DocPath, serializedState);
     }
 

--- a/BudgetAnalyzer.Shared/Data/State/StateManager.cs
+++ b/BudgetAnalyzer.Shared/Data/State/StateManager.cs
@@ -1,9 +1,12 @@
-﻿namespace BudgetAnalyzer.Shared.State;
+﻿using System.Text.Json;
+
+namespace BudgetAnalyzer.Shared.State;
 
 public class StateManager
 {
-    public AnalyzerState State => _State ?? throw new NullReferenceException($"{nameof(State)} can not be null");
-    private AnalyzerState _State = new();
+    private static readonly string DocPath = AppDomain.CurrentDomain.BaseDirectory + "AppData.json";
+    public AnalyzerState State => _State;
+    private AnalyzerState _State = LoadState();
 
     private event EventHandler<AnalyzerState>? StateChanged;
 
@@ -11,6 +14,26 @@ public class StateManager
     {
         _State = action.UpdateState(_State);
         StateChanged?.Invoke(this, _State);
+        SaveState();
+    }
+    
+    private static AnalyzerState LoadState()
+    {
+        if (!File.Exists(DocPath))
+        {
+            AnalyzerState defaultState = new();
+            File.WriteAllText(DocPath, defaultState.ToJson(true));
+            return defaultState;
+        }
+
+        string serializedState = File.ReadAllText(DocPath);
+        return AnalyzerState.FromJson(serializedState);
+    }
+
+    private void SaveState()
+    {
+        string serializedState = _State.ToJson(true);
+        File.WriteAllText(DocPath, serializedState);
     }
 
     public void Subscribe(EventHandler<AnalyzerState> action) => StateChanged += action;

--- a/BudgetAnalyzer.Shared/Data/State/StateManager.cs
+++ b/BudgetAnalyzer.Shared/Data/State/StateManager.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json;
-
-namespace BudgetAnalyzer.Shared.State;
+﻿namespace BudgetAnalyzer.Shared.State;
 
 public class StateManager
 {

--- a/BudgetAnalyzer.Shared/_Imports.razor
+++ b/BudgetAnalyzer.Shared/_Imports.razor
@@ -1,5 +1,6 @@
 @using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Forms
 @using MudBlazor
 @using BudgetAnalyzer.Shared.State
 @using BudgetAnalyzer.Shared.Controls

--- a/BudgetAnalyzer/BudgetAnalyzer.csproj
+++ b/BudgetAnalyzer/BudgetAnalyzer.csproj
@@ -29,6 +29,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="CommunityToolkit.Maui" Version="9.0.3" />
         <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.80" />
         <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.80" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="8.0.80" />

--- a/BudgetAnalyzer/MauiProgram.cs
+++ b/BudgetAnalyzer/MauiProgram.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using MudBlazor.Services;
 using BudgetAnalyzer.Shared.State;
+using CommunityToolkit.Maui;
 
 namespace BudgetAnalyzer
 {
@@ -11,6 +12,7 @@ namespace BudgetAnalyzer
             var builder = MauiApp.CreateBuilder();
             builder
                 .UseMauiApp<App>()
+                .UseMauiCommunityToolkit()
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
@@ -19,7 +21,7 @@ namespace BudgetAnalyzer
             builder.Services.AddMauiBlazorWebView();
             builder.Services.AddMudServices();
 
-            // State Management
+            // App Services
             builder.Services.AddSingleton<StateManager>();
 
             #if DEBUG


### PR DESCRIPTION
- State is now saved automatically to a local (pretty hidden) file that is not a hard-coded path
- Can Upload and Download the app data to a json file as needed
- Can copy app data

NOTE: Added CommunityToolkit.MAUI, meaning the app is now MAUI specific. If the capacity is needed, I'm sure this could be adjusted in the future to support web, but that was going to take a lot more work so I just put it all in a static class that can be refactored if ever needed