### PR TITLE
Created Save / Reset Button for App Settings editor 

### DIFF
--- a/BudgetAnalyzer.Shared/Components/Controls/AppSettingsEditor.razor
+++ b/BudgetAnalyzer.Shared/Components/Controls/AppSettingsEditor.razor
@@ -2,10 +2,10 @@
 @namespace BudgetAnalyzer.Shared.Controls
 @inherits SubscribedComponent
 
-<MudStack Row="true" AlignItems="AlignItems.Baseline">
+<MudStack Row="true" AlignItems="AlignItems.Baseline" Class="mb-4">
     <MudText>Selected Budget: </MudText>
 
-    <MudSelect @bind-Value:get=Settings.CurrentBudgetId @bind-Value:set=SetSelectedBudget>
+    <MudSelect @bind-Value:get=EditedSettings.CurrentBudgetId @bind-Value:set=@((Guid selectedId) => EditedSettings = EditedSettings with {CurrentBudgetId = selectedId} )>
         <MudSelectItem Disabled="true" Value="default(Guid)">None</MudSelectItem>
         @foreach(Budget budget in State.AvailableBudgets)
         {
@@ -14,7 +14,10 @@
     </MudSelect>
 </MudStack>
 
-<MudStack Spacing="0" Class="mt-4">
+<MudButton Variant="Variant.Filled" OnClick="SaveSettings" Disabled="(!IsChanged)" Color="Color.Info">Save Settings</MudButton>
+<MudButton Variant="Variant.Filled" OnClick="SetToDefault" Disabled="(!IsChanged)">Reset</MudButton>
+
+<MudStack Spacing="0">
     <MudButton Variant="Variant.Text" OnClick="() => ShowState = !ShowState">Show Current App Data</MudButton>
     <MudDivider />
     <MudCollapse Expanded="ShowState">
@@ -26,8 +29,20 @@
 
 
 @code {
-    private AppSettings Settings => State.Settings;
-    private bool ShowState { get; set; } = false;
+    private AppSettings CurrentSettings => State.Settings;
+    private AppSettings EditedSettings { get; set; } = default!;
 
-    private void SetSelectedBudget(Guid selectedBudget) => AddAction(new SetSelectedBudgetAction(selectedBudget));
+    private bool ShowState { get; set; } = false;
+    private bool IsChanged => !(CurrentSettings == EditedSettings);
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        EditedSettings = CurrentSettings;
+    }
+
+    private void SetToDefault() => EditedSettings = CurrentSettings;
+
+    private void SaveSettings() => AddAction(new UpdateSettingsAction(EditedSettings));
+
 }

--- a/BudgetAnalyzer.Shared/Data/State/Actions/DeleteBudgetAction.cs
+++ b/BudgetAnalyzer.Shared/Data/State/Actions/DeleteBudgetAction.cs
@@ -1,4 +1,6 @@
-﻿namespace BudgetAnalyzer.Shared.State;
+﻿using BudgetAnalyzer.Shared.Data;
+
+namespace BudgetAnalyzer.Shared.State;
 
 public class DeleteBudgetAction(Guid BudgetIdToDelete) : IAction
 {
@@ -9,7 +11,8 @@ public class DeleteBudgetAction(Guid BudgetIdToDelete) : IAction
         if(BudgetIdToDelete == state.Settings.CurrentBudgetId)
         {
             Guid newSelection = state.AvailableBudgets.Select(b => b.Id).FirstOrDefault();
-            state = (new SetSelectedBudgetAction(newSelection)).UpdateState(state);
+            AppSettings updatedSettings = state.Settings with { CurrentBudgetId = newSelection };
+            state = (new UpdateSettingsAction(updatedSettings)).UpdateState(state);
         }
 
         return state;

--- a/BudgetAnalyzer.Shared/Data/State/Actions/SetSelectedBudgetAction.cs
+++ b/BudgetAnalyzer.Shared/Data/State/Actions/SetSelectedBudgetAction.cs
@@ -1,6 +1,0 @@
-﻿namespace BudgetAnalyzer.Shared.State;
-
-public record SetSelectedBudgetAction(Guid SelectedBudgetId): IAction
-{
-    public AnalyzerState UpdateState(AnalyzerState state) => state with { Settings = state.Settings with { CurrentBudgetId = SelectedBudgetId } };
-}

--- a/BudgetAnalyzer.Shared/Data/State/Actions/UpdateSettingsAction.cs
+++ b/BudgetAnalyzer.Shared/Data/State/Actions/UpdateSettingsAction.cs
@@ -1,0 +1,8 @@
+﻿using BudgetAnalyzer.Shared.Data;
+
+namespace BudgetAnalyzer.Shared.State;
+
+public record UpdateSettingsAction(AppSettings NewSettings): IAction
+{
+    public AnalyzerState UpdateState(AnalyzerState state) => state with { Settings = NewSettings };
+}


### PR DESCRIPTION
- As explained in issue #12 , it didn't make a ton of sense stylistically to automatically update the state with settings changes, but not budget changes, and would quickly become problematic if a invalid state was ever saved.
- Changed to where settings are updated as a whole, not piece by piece.
  - Could theoretically add separate actions in the future but holding off for now