### PR TITLE
Implemented Monthly Income

### DIFF
--- a/BudgetAnalyzer.Shared/Components/Controls/BudgetEditor.razor
+++ b/BudgetAnalyzer.Shared/Components/Controls/BudgetEditor.razor
@@ -9,6 +9,11 @@
     <ToolBarContent>
         <MudTextField Label="Budget Name" @bind-Value:get=EditedBudget.Name @bind-Value:set=@((string newName) => EditedBudget = EditedBudget with {Name = newName}) Immediate="true" />
         <MudSpacer />
+
+        <MudNumericField Label="Estimated Monthly Income" Min="0" Step="50" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.AttachMoney" Immediate="true"
+                         @bind-Value:get=EditedBudget.MonthlyIncome @bind-Value:set=@((decimal newVal) => EditedBudget = EditedBudget with {MonthlyIncome = newVal})  />
+        <MudSpacer />
+
         <MudButton StartIcon="@Icons.Material.Filled.Add" OnClick="AddCategory">Add New Category</MudButton>
     </ToolBarContent>
 
@@ -16,6 +21,7 @@
         <MudTh>Name</MudTh>
         <MudTh>% of Income</MudTh>
         <MudTh>Cutoff</MudTh>
+        <MudTh>$ / Month</MudTh>
         <MudTh>&nbsp;</MudTh>
     </HeaderContent>
 
@@ -23,23 +29,27 @@
         <MudTd DataLabel="Name">@context.Name</MudTd>
         <MudTd DataLabel="% of Income">@context.Percentage.ToString("F1")</MudTd>
         <MudTd DataLabel="Cutoff">@(context.Cutoff is null ? "N/A" : context.Cutoff.ToString())</MudTd>
+        <MudTd DataLabel="$ / Month">@(context.Percentage.PercentOf(EditedBudget.MonthlyIncome))</MudTd>
         <MudTd> <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" OnClick="() => RemoveCategory(context)" /> </MudTd>
     </RowTemplate>
 
     <RowEditingTemplate>
         <MudTd DataLabel="Name">
-            <MudTextField @bind-Value:get=TempCategory.Name @bind-Value:set=@((string newName) => TempCategory = TempCategory with {Name = newName}) DebounceInterval="500"/>
+            <MudTextField @bind-Value:get=TempCategory.Name @bind-Value:set=@((string newName) => TempCategory = TempCategory with {Name = newName}) Immediate="true"/>
         </MudTd>
 
         <MudTd DataLabel="% of Income">
-            <MudNumericField T="decimal" Min="0" Max="100" Step="10M" DebounceInterval="500"
-                             @bind-Value:get=TempCategory.Percentage @bind-Value:set=@((decimal newVal) => TempCategory = TempCategory with {Percentage = newVal}) />
+            <MudNumericField T="decimal" Min="0" Max="100" Step="10" Immediate="true"
+                             @bind-Value:get=(decimal)TempCategory.Percentage @bind-Value:set=@((decimal newVal) => TempCategory = TempCategory with {Percentage = newVal}) />
         </MudTd>
 
         <MudTd DataLabel="Cutoff">
-            <MudNumericField T="decimal?" Min="0" Step="50M" DebounceInterval="500"
+            <MudNumericField T="decimal?" Min="0" Step="50" Immediate="true"
                              @bind-Value:get=TempCategory.Cutoff @bind-Value:set=@((decimal? newVal) => TempCategory = TempCategory with {Cutoff = newVal}) />
         </MudTd>
+
+        <MudTd DataLabel="$ / Month" />
+        <MudTd DataLabel="&nbsp;" />
     </RowEditingTemplate>
 </MudTable>
 

--- a/BudgetAnalyzer.Shared/Data/Budget.cs
+++ b/BudgetAnalyzer.Shared/Data/Budget.cs
@@ -9,15 +9,15 @@ public record BudgetCategory(string Name, Percentage Percentage, decimal? Cutoff
     public static BudgetCategory Default => new("Default Cagetory", 0, null); 
 }
 
-public sealed record Budget(string Name, ImmutableList<BudgetCategory> Categories)
+public sealed record Budget(string Name, decimal MonthlyIncome, ImmutableList<BudgetCategory> Categories)
 {
     public Guid Id { get; init; } = Guid.NewGuid();
-    public static Budget Default => new("Default Budget", []);
+    public static Budget Default => new("Default Budget", 500, []);
 
     public bool IsValid(out string? errorMessage)
     {
         errorMessage = null;
-        if (Categories.Sum(c => c.Percentage) > 100)
+        if (Categories.Sum(c => (decimal)c.Percentage) > 100)
             errorMessage = "Percentages should sum to no more that 100%";
 
         return string.IsNullOrWhiteSpace(errorMessage);
@@ -34,6 +34,7 @@ public sealed record Budget(string Name, ImmutableList<BudgetCategory> Categorie
     {
         if (other == null) return false;
         return Name == other.Name
+               && MonthlyIncome == other.MonthlyIncome
                && Categories.SequenceEqual(other.Categories);
     } 
 

--- a/BudgetAnalyzer.Shared/Data/Percentage.cs
+++ b/BudgetAnalyzer.Shared/Data/Percentage.cs
@@ -1,4 +1,6 @@
-﻿namespace BudgetAnalyzer.Shared.Data;
+﻿using System.Text.Json.Serialization;
+
+namespace BudgetAnalyzer.Shared.Data;
 
 /// <summary>
 /// Attempts to make working with percentages similar to how it would be done if writing on math on paper.
@@ -6,12 +8,13 @@
 /// </summary>
 public readonly struct Percentage
 {
+    [JsonInclude]
     private decimal FractionalValue { get; init; }
 
     /// <summary> Creates a new percentage instance. Value should be the numerical percentage ie 10% = "10" </summary>
     public Percentage(decimal percentValue) => FractionalValue = (percentValue / 100);
     public static implicit operator Percentage(decimal value) => new(value);
-    public static implicit operator decimal(Percentage value) => value.FractionalValue * 100;
+    public static explicit operator decimal(Percentage value) => value.FractionalValue * 100;
 
     /// <summary> Converts the percentage to a round-trip string, leaving off the '%' character.</summary>
     public override string ToString() => (FractionalValue * 100).ToString("R");

--- a/BudgetAnalyzer.Shared/Data/State/Actions/UpdateBudget.cs
+++ b/BudgetAnalyzer.Shared/Data/State/Actions/UpdateBudget.cs
@@ -3,15 +3,12 @@ using System.Collections.Immutable;
 
 namespace BudgetAnalyzer.Shared.State;
 
-public record UpdateBudget(Guid BudgetId, string Name, IEnumerable<BudgetCategory> Categories) : IAction
+public record UpdateBudget(Budget updatedBudget) : IAction
 {
-    public UpdateBudget(Budget updatedBudget) : this(updatedBudget.Id, updatedBudget.Name, updatedBudget.Categories) { }
-
     public AnalyzerState UpdateState(AnalyzerState state)
     {
-        Budget originalBudget = state.AvailableBudgets.Single(b => b.Id == BudgetId);
-        Budget newBudget =  originalBudget with { Name = Name, Categories = Categories.ToImmutableList() };
+        Budget originalBudget = state.AvailableBudgets.Single(b => b.Id == updatedBudget.Id);
 
-        return state with { AvailableBudgets = state.AvailableBudgets.Replace(originalBudget, newBudget) };
+        return state with { AvailableBudgets = state.AvailableBudgets.Replace(originalBudget, updatedBudget) };
     }
 }


### PR DESCRIPTION
- Update budget action now only allows you to give a new budget of same ID
- Percentage class now serializes properly, changed the Percentage => decimal operator to explicit to prevent invalid math operations
- Monthly income is stored as decimal on budget
- Created additional column on budget editor for calculating how much goes to each category

Closes #10 